### PR TITLE
Changed charthour to pull hour instead of starttime

### DIFF
--- a/11_hourly_patient_vent_status.sql
+++ b/11_hourly_patient_vent_status.sql
@@ -9,11 +9,10 @@ SELECT
   subject_id,
   hadm_id,
   stay_id,
-  DATETIME_TRUNC(starttime,
+  DATETIME_TRUNC(hour,
     HOUR) AS chart_hour,
   starttime,
   endtime,
-  day,
   TRUE AS ventilated
 FROM
   `physionet-data.mimic_icu.procedureevents`
@@ -22,6 +21,6 @@ JOIN
           HOUR)),
       TIMESTAMP(DATETIME_TRUNC(endtime,
           HOUR)),
-      INTERVAL 1 HOUR)) DAY
+      INTERVAL 1 HOUR)) hour
 WHERE
   ordercategoryname = "Ventilation"


### PR DESCRIPTION
The previous vent query had several issues that Alistair pointed out and that I found while exploring the vent status table:

- [ ] The unnested hours between startime and endtime are confusingly referred to as "day" instead of hour
- [ ] The charthour truncates the wrong field! It truncates starttime instead of the unnested generated hours, so it ends up creating N rows with duplicate chartthours instead of N rows with N different chartthours
- [ ] Alistair pointed out that ordercategoryname = Ventilation is wrong, instead we should pull the right item_id

So far this PR addresses the first two but not the last 1 
